### PR TITLE
Adds FR to jalv.select.desktop

### DIFF
--- a/jalv.select.desktop
+++ b/jalv.select.desktop
@@ -1,11 +1,10 @@
-
 [Desktop Entry]
 Version=1.0
 Type=Application
 Name=jalv.select
 Comment=Simple Interface for jalv
+Comment[fr]=Interface simple pour jalv
 Exec=jalv.select
 Icon=lv2
 Categories=AudioVideo;Audio;
 Terminal=false
-Name[de_DE]=jalv.select


### PR DESCRIPTION
Adding a FR comment to the desktop file.
I enjoyed this edit to remove the white line at the beginning and also the Name[de] which doesn't seems to add anything given it doesn't provide an alternative German name. Hope I'm not wrong here.
